### PR TITLE
Fix legacy assembler for LLVM GCC 4.2

### DIFF
--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -556,8 +556,10 @@ AS_RESULT=255
 if [ "\$ARCH_FOUND" -eq '1' ]; then
         if [ -x "\$AS_DIR/../../../as/\$ARCH/as" ]; then
                 AS="\$AS_DIR/../../../as/\$ARCH/as"
+        elif [ -x "\$AS_DIR/../../../../../libexec/as/\$ARCH/as" ]; then
+                AS="\$AS_DIR/../../../../../libexec/as/\$ARCH/as"
         else
-                echo "Error: cannot find as for \$ARCH in \$AS_DIR/../../../as/\$ARCH"
+                echo "Error: cannot find as for \$ARCH in \$AS_DIR/../../../as/\$ARCH or \$AS_DIR/../../../../../libexec/as/\$ARCH"
                 exit 1
         fi
 

--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -195,7 +195,7 @@ case $1 in
             echo "or"
             echo " https://adcdownload.apple.com/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg"
             echo "and then run this script from within the same directory as the downloaded file"
-            exit
+            missingdmg=1
         fi
         if [ "$xc5" = 1 ] && [ ! -f xcode_5.1.1.dmg ]; then
             echo "*** you should download Xcode 5.1.1. Login to:"
@@ -1078,7 +1078,7 @@ SPEC_EOF
                     rm $GCCLINKDIR/bin/$b
                 fi
             done
-            for b in cpp-4.2.1 gcc-4.0.1 g++-4.0.1 gcc-4.2.1 g++-4.2.1 llvm-g++-4.2 llvm-gcc-4.2; do 
+            for b in cpp-4.2.1 gcc-4.0.1 g++-4.0.1 gcc-4.2.1 g++-4.2.1 llvm-g++-4.2 llvm-gcc-4.2; do
                 if [ -L $GCCLINKDIR/bin/i686-apple-darwin10-$b ] && [ ! -e $GCCLINKDIR/bin/i686-apple-darwin10-$b ]; then
                     rm $GCCLINKDIR/bin/i686-apple-darwin10-$b
                 fi

--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -181,9 +181,9 @@ case $1 in
             echo "*** you should download Xcode 3.2.6. Login to:"
             echo " https://developer.apple.com/downloads/"
             echo "then download from:"
-            echo " http://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg"
+            echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg"
             echo "or"
-            echo " http://adcdownload.apple.com/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg"
+            echo " https://adcdownload.apple.com/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg"
             echo "and then run this script from within the same directory as the downloaded file"
             missingdmg=1
         fi
@@ -193,7 +193,7 @@ case $1 in
             echo "then download from:"
             echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg"
             echo "or"
-            echo " http://adcdownload.apple.com/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg"
+            echo " https://adcdownload.apple.com/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg"
             echo "and then run this script from within the same directory as the downloaded file"
             exit
         fi
@@ -203,7 +203,7 @@ case $1 in
             echo "then download from:"
             echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg"
             echo "or"
-            echo " http://adcdownload.apple.com/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg"
+            echo " https://adcdownload.apple.com/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg"
             echo "and then run this script from within the same directory as the downloaded file"
             missingdmg=1
         fi
@@ -211,9 +211,9 @@ case $1 in
             echo "*** you should download Xcode 6.4. Login to:"
             echo " https://developer.apple.com/downloads/"
             echo "then download from:"
-            echo " http://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg"
+            echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg"
             echo "or"
-            echo " http://adcdownload.apple.com/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg"
+            echo " https://adcdownload.apple.com/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg"
             echo "and then run this script from within the same directory as the downloaded file"
             missingdmg=1
         fi
@@ -221,9 +221,9 @@ case $1 in
             echo "*** you should download Xcode 7.3.1. Login to:"
             echo " https://developer.apple.com/downloads/"
             echo "then download from:"
-            echo " http://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg"
+            echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg"
             echo "or"
-            echo " http://adcdownload.apple.com/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg"
+            echo " https://adcdownload.apple.com/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg"
             echo "and then run this script from within the same directory as the downloaded file"
             missingdmg=1
         fi


### PR DESCRIPTION
When compiling with LLVM GCC 4.2, `$AS_DIR` is `XcodeDefault.xctoolchain/usr/llvm-gcc-4.2/libexec/gcc/(i686|powerpc)-apple-darwin10/4.2.1`, so the as script needs to look up two more directory levels to find `XcodeDefault.xctoolchain/usr/libexec/as/$ARCH/as`.

I also switched all the DMG links to HTTPS and fixed a minor bug.