### PR TITLE
Intermediate `as` shell script fixes

### DIFF
--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -661,10 +661,9 @@ ARCH_FOUND=0
 AS_ARGS=()
 for var in "\$@"
 do
-        if [ "\$ARCH_FOUND" -eq '1' ]; then
-                ARCH=\$var
+        if [ -z "\$ARCH" ] && [ "\$ARCH_FOUND" -eq '1' ]; then
+                ARCH="\$var"
                 AS_ARGS+=("\$var")
-                break
         elif [ "\$var" = '-arch' ]; then
                 ARCH_FOUND=1
                 AS_ARGS+=("\$var")
@@ -692,7 +691,7 @@ if [ "\$ARCH_FOUND" -eq '1' ]; then
         fi
 fi
 if [ "\$AS_FOUND" -eq '1' ]; then
-        exec \$AS "\${AR_ARGS[@]}"
+        exec \$AS "\${AS_ARGS[@]}"
 else
         if [ -x "\$AS_DIR/as-original" ]; then
                 ASORIGINAL="\$AS_DIR/as-original"


### PR DESCRIPTION
Hello, long-time no-see :)

The intermediate `as` shell script (that I wrote originally and whose sole job is to strip "bad" arguments given to legacy `as` programs) had a simple typo in it and was also stripping any arguments past the "-arch" argument errantly (due to the way the loop was configured). Both issues fixed in this pull request.
