### PR TITLE
Use plutil for XCode 10's binary platform plist

### DIFF
--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -1038,7 +1038,7 @@ SPEC_EOF
             echo "*** Not modifying MacOSX Info.plist (found original at $PLATFORMDIR/Info.plist-original, uninstall first to force install)"
         elif [ -f "$PLATFORMDIR/Info.plist" ]; then
             mv "$PLATFORMDIR/Info.plist" "$PLATFORMDIR/Info.plist-original"
-            sed -e '/MinimumSDKVersion/{N;d;}' < "$PLATFORMDIR/Info.plist-original" > "$PLATFORMDIR/Info.plist"
+            plutil -remove MinimumSDKVersion -o "$PLATFORMDIR/Info.plist" "$PLATFORMDIR/Info.plist-original"
             echo "*** modified MacOSX Info.plist"
         fi
 


### PR DESCRIPTION
XCode 10.0 uses a binary-formatted plist for ``/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform``, and ``sed`` will convert to an empty file, causing issues with ``xcodebuild`` and other tools (issue #46). ``plutil`` handles both binary and XML-formated plist files, as [suggested](https://github.com/devernay/xcodelegacy/issues/46#issuecomment-437678762) by @nicolas-cellier-aka-nice.