### PR TITLE
Pull request to fix potential hanging bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Description
 
 Many components were removed in recent versions of Xcode, the most notable being the Mac OS X 10.6 SDK, which is required to build software using the Carbon API (such as wxWidgets 2.8).
 
-I made the script XcodeLegacy.sh to extract these components (the links work if you [sign in to Apple Developer](https://developer.apple.com/downloads/) first) from [Xcode 3.2.6](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg) (10.4, 10.5 and 10.6 SDKs, PPC assembler, GCC 4.0 and 4.2, LLVM-GCC 4.2), [Xcode 4.6.3](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg) (10.7 SDK), [Xcode 5.1.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg) (10.8 SDK), [Xcode 6.4](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg) (10.9 and 10.10 SDKs), [Xcode 7.3.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) (10.11 SDK), [Xcode 8.3.3](https://download.developer.apple.com/Developer_Tools/Xcode_8.3.3/Xcode8.3.3.xip) (10.12 SDK), [Xcode 9.4.1](https://download.developer.apple.com/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip) (10.13 SDK) and install them in Xcode 4-10:
+I made the script XcodeLegacy.sh to extract these components (the links work if you [sign in to Apple Developer](https://developer.apple.com/downloads/) first) from [Xcode 3.2.6](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg) (10.4, 10.5 and 10.6 SDKs, PPC assembler, GCC 4.0 and 4.2, LLVM-GCC 4.2), [Xcode 4.6.3](https://download.developer.apple.com/Developer_Tools/xcode_4.6.3/Xcode_4.6.3.dmg) (10.7 SDK), [Xcode 5.1.1](https://download.developer.apple.com/Developer_Tools/xcode_5.1.1/Xcode_5.1.1.dmg) (10.8 SDK), [Xcode 6.4](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg) (10.9 and 10.10 SDKs), [Xcode 7.3.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) (10.11 SDK), [Xcode 8.3.3](https://download.developer.apple.com/Developer_Tools/Xcode_8.3.3/Xcode_8.3.3.xip) (10.12 SDK), [Xcode 9.4.1](https://download.developer.apple.com/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip) (10.13 SDK) and install them in Xcode 4-10:
 
 - GCC 4.0, GCC 4.2 and LLVM GCC 4.2 compilers
 - GCC 4.0, GCC 4.2 and LLVM GCC 4.2 Xcode plugins
@@ -52,6 +52,7 @@ Optionally, one of the following options can be passed as the *first* argument t
 * `-osx1011` : only install OSX 10.11 SDK
 * `-osx1012` : only install OSX 10.12 SDK
 * `-osx1013` : only install OSX 10.13 SDK
+* `-path=path` : install to custom Xcode at 'path'
 
 
 Using the older SDKs
@@ -105,16 +106,18 @@ Here are the latest versions of Xcode that are known to /run/ on each OS X versi
 
 - [Xcode 2.5](http://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_2.5_developer_tools/xcode25_8m2558_developerdvd.dmg) on Mac OS X 10.4 (Tiger) (*)
 - [Xcode 3.1.4](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.1.4_developer_tools/xcode314_2809_developerdvd.dmg) on Mac OS X 10.5 (Leopard) (*)
-- [Xcode 3.2.6](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg) on Mac OS X 10.6 (Snow Leopard) - [Xcode 4.0.2](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.0.2_and_ios_sdk_4.3/xcode_4.0.2_and_ios_sdk_4.3.dmg), [Xcode 4.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.1_for_snow_leopard_21110/xcode_4.1_for_snow_leopard.dmg) and [Xcode 4.2](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.2_with_ios_5_sdk/xcode_4.2_and_ios_5_sdk_for_snow_leopard.dmg) also run on Snow Leopard, but are only available to pay members (*)
-- [Xcode 4.6.3](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg) on OS X 10.7 (Lion)
-- [Xcode 5.1.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg) on OS X 10.8 (Mountain Lion)
+- [Xcode 3.2.6](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg) on Mac OS X 10.6 (Snow Leopard) - [Xcode 4.0.2](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.0.2_and_ios_sdk_4.3/xcode_4.0.2_and_ios_sdk_4.3.dmg), [Xcode 4.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.1_for_snow_leopard_21110/xcode_4.1_for_snow_leopard.dmg) and [Xcode 4.2](https://download.developer.apple.com/Developer_Tools/xcode_4.2_for_snow_leopard/xcode_4.2_for_snow_leopard.dmg) also run on Snow Leopard, but are only available to pay members (*)
+- [Xcode 4.6.3](https://download.developer.apple.com/Developer_Tools/xcode_4.6.3/Xcode_4.6.3.dmg) on OS X 10.7 (Lion)
+- [Xcode 5.1.1](https://download.developer.apple.com/Developer_Tools/xcode_5.1.1/Xcode_5.1.1.dmg) on OS X 10.8 (Mountain Lion)
 - [Xcode 6.2](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.2/Xcode_6.2.dmg) on OS X 10.9 (Mavericks)
 - [Xcode 7.2.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.2.1/Xcode_7.2.1.dmg) on OS X 10.10 (Yosemite)
-- [Xcode 7.3.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) on OS X 10.11 (El Capitan), please see note on linking below. [Xcode 8.2.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_8.2.1/Xcode_8.2.1.xip) also runs on OS X 10.11, but can only compile for macOS 10.12.
-- [Xcode 8.3.3](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_8.3.3/Xcode8.3.3.xip) on macOS 10.12 (Sierra), please see note on linking below.
-- [Xcode 9.4.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip) on macOS 10.13 (High Sierra), please see note on linking below.
+- [Xcode 7.3.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) on OS X 10.11 (El Capitan), please see note on linking below. [Xcode 8.2.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_8.2.1/Xcode_8.2.1.xip) (**) also runs on OS X 10.11, but can only compile for macOS 10.12.
+- [Xcode 8.3.3](https://download.developer.apple.com/Developer_Tools/Xcode_8.3.3/Xcode_8.3.3.xip) on macOS 10.12 (Sierra), please see note on linking below. (**)
+- [Xcode 9.4.1](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip) on macOS 10.13 (High Sierra), please see note on linking below. (**)
 
 (*) These Xcode versions were released before 26.03.2012 and may cause an "An unknown installation error" during installation, which is due to an expired certificate. Installing these may require disabling network time sync and setting the date to 01.01.2012 before installing. Network time sync may be re-enabled after install. See [this stackexchange question](https://apple.stackexchange.com/questions/45841/xcode-4-2-snow-leopard-doesnt-install) for more details.
+
+ (**) If you downloaded these Xcode versions (8.2.1, 8.3.3, 9.4.1) before 24th October 2019 the certificate used to sign them has expired and Archive Utility will refuse to unpack them. See [this TidBITS article](https://tidbits.com/2019/10/28/redownload-archived-macos-installers-to-address-expired-certificates/) which describes the same problem in OS installers for more details. XcodeLagacy now checks for this problem and prompts you to re-download the archives which now have updated signatures.
 
 More information about the compilers included in each version of Xcode can be found on the [MacPorts Wiki](https://trac.macports.org/wiki/XcodeVersionInfo) and on [Wikipedia](https://en.wikipedia.org/wiki/Xcode).
 
@@ -211,3 +214,5 @@ History
 - 2.0 (02/05/2017): Xcode 8 cannot always link i386 for OS X 10.5, use the Xcode 3 linker for this arch too. Force use of legacy assembler with GCC 4.x.
 - 2.1 (17/01/2017): Xcode 9 dropped 10.12 SDK, get it from Xcode 8.3.3; fix compiling with GNU Ada, and many other fixes
 - 2.2 (10/01/2019): Xcode 10 dropped 10.13 SDK, get it from Xcode 9.4.1
+- 2.3 (27/03/2019): Added an option to install in a custom Xcode path
+- 2.4 (10/02/2020): Fix for buildpackages if Xcode 8 or Xcode 9 xip have expired signatures. Also now check for stray Xcode.app if extracting Xcode 9.4.1, Fixes for changed download paths and archive names.

--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -9,6 +9,7 @@
 # - Chris Roueche <croueche@github>
 # - Kris Coppieters <zwettemaan@github>
 # - Nick Beadman <nbeadman@gmail.com> / <nbeadman@github>
+# - Alan Staniforth <apollonia.uk@gmail.com>
 #
 # License: Creative Commons BY-NC-SA 3.0 http://creativecommons.org/licenses/by-nc-sa/3.0/
 #

--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -320,7 +320,7 @@ case $1 in
             echo "*** at least one Xcode distribution is missing, cannot build packages - exiting now"
             exit
         fi
-        if [ "$xc8" = 1 ]; then
+        if [ "$xc8" = 1 ] || [ "$xc9" = 1 ]; then
             if [ -e Xcode.app ]; then
                 echo "*** A stray Xcode.app exists in the XcodeLegacy.sh folder. Remove it then try again."
                 exit

--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -27,7 +27,7 @@
 # 2.1 (17/01/2017): Xcode 9 dropped 10.12 SDK, get it from https://github.com/phracker/MacOSX-SDKs; fix compiling with GNU Ada, and many other fixes
 # 2.2 (12/02/2019): Added support for using macOS High Sierra 10.13 SDK from Xcode 9.4.1 for use on Xcode 10/macOS 10.14 Mojave, also changed source of OS X 10.12 SDK to Xcode 8.3.3
 # 2.3 (27/03/2019): Added an option to install in a custom Xcode path
-# 2.4 (10/02/2020): Fix for buildpackages if Xcode 8 or Xcode 9 xip have expired signatures. Also now check for stray Xcode.app if extracting Xcode 9.4.1, Fixes for changed download path and archive names.
+# 2.4 (10/02/2020): Fix for buildpackages if Xcode 8 or Xcode 9 xip have expired signatures. Also now check for stray Xcode.app if extracting Xcode 9.4.1, Fixes for changed download paths and archive names.
 
 #set -e # Exit immediately if a command exits with a non-zero status
 #set -u # Treat unset variables as an error when substituting.

--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -261,22 +261,25 @@ case $1 in
             missingdmg=1
         fi
         if [ "$xc4" = 1 ] && [ ! -f xcode4630916281a.dmg ]; then
-            echo "*** You should download Xcode 4.6.3. Login to:"
-            echo " https://developer.apple.com/downloads/"
-            echo "then download from:"
-            echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg"
-            echo "or"
-            echo " https://adcdownload.apple.com/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg"
-            echo "and then run this script from within the same directory as the downloaded file"
-            missingdmg=1
+            xcode4archive="xcode4630916281a.dmg"
+            if [ ! -f xcode4630916281a.dmg ] && [ ! -f Xcode_4.6.3.dmg ]; then
+                echo "*** You should download Xcode 4.6.3. Login to:"
+                echo " https://developer.apple.com/downloads/"
+                echo "then download from:"
+                echo " https://download.developer.apple.com/Developer_Tools/xcode_4.6.3/Xcode_4.6.3.dmg"
+                echo "and then run this script from within the same directory as the downloaded file"
+                missingdmg=1
+            else
+                if [ -f Xcode_4.6.3.dmg ]; then
+                    xcode4archive="Xcode_4.6.3.dmg"
+                fi
+            fi
         fi
         if [ "$xc5" = 1 ] && [ ! -f xcode_5.1.1.dmg ]; then
             echo "*** You should download Xcode 5.1.1. Login to:"
             echo " https://developer.apple.com/downloads/"
             echo "then download from:"
-            echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg"
-            echo "or"
-            echo " https://adcdownload.apple.com/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg"
+            echo " https://download.developer.apple.com/Developer_Tools/xcode_5.1.1/Xcode_5.1.1.dmg"
             echo "and then run this script from within the same directory as the downloaded file"
             missingdmg=1
         fi
@@ -532,7 +535,7 @@ EOF
         fi
 
         if [ "$xc4" = 1 ]; then
-            hdiutil attach xcode4630916281a.dmg "${ATTACH_OPTS[@]}"
+            hdiutil attach "$xcode4archive" "${ATTACH_OPTS[@]}"
             if [ ! -d "$MNTDIR/Xcode" ]; then
                 echo "*** Error while trying to attach disk image xcode4630916281a.dmg"
                 echo "Aborting"

--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -27,6 +27,7 @@
 # 2.1 (17/01/2017): Xcode 9 dropped 10.12 SDK, get it from https://github.com/phracker/MacOSX-SDKs; fix compiling with GNU Ada, and many other fixes
 # 2.2 (12/02/2019): Added support for using macOS High Sierra 10.13 SDK from Xcode 9.4.1 for use on Xcode 10/macOS 10.14 Mojave, also changed source of OS X 10.12 SDK to Xcode 8.3.3
 # 2.3 (27/03/2019): Added an option to install in a custom Xcode path
+# 2.4 (10/02/2020): Fix for buildpackages if Xcode 8 or Xcode 9 xip have expired signatures. Also now check for stray Xcode.app if extracting Xcode 9.4.1, Fixes for changed download path and archive names.
 
 #set -e # Exit immediately if a command exits with a non-zero status
 #set -u # Treat unset variables as an error when substituting.
@@ -303,21 +304,64 @@ case $1 in
             echo "and then run this script from within the same directory as the downloaded file"
             missingdmg=1
         fi
-        if [ "$xc8" = 1 ] && [ ! -f Xcode8.3.3.xip ]; then
-            echo "*** You should download Xcode 8.3.3. Login to:"
-            echo " https://developer.apple.com/downloads/"
-            echo "then download from:"
-            echo " https://download.developer.apple.com/Developer_Tools/Xcode_8.3.3/Xcode8.3.3.xip"
-            echo "and then run this script from within the same directory as the downloaded file"
-            missingdmg=1
+        if [ "$xc8" = 1 ]; then        
+			xcode8archive="Xcode_8.3.3.xip"
+			validarcfound=0
+			noarcfound=0
+			if [ ! -f Xcode_8.3.3.xip ] && [ ! -f Xcode8.3.3.xip ]; then
+				echo "*** You should download Xcode 8.3.3. Login to:"
+				noarcfound=1
+			else
+				if [ -f Xcode8.3.3.xip ]; then
+					pkgutil --check-signature Xcode8.3.3.xip
+					if [ "$?" = 0 ]; then
+						xcode8archive="Xcode8.3.3.xip"
+						validarcfound=1
+					fi
+				fi
+				if [ -f Xcode_8.3.3.xip ] && [ "$validarcfound" = 0 ]; then
+                    pkgutil --check-signature Xcode_8.3.3.xip
+                    if [ "$?" = 0 ]; then
+                        validarcfound=1
+                    fi
+                fi
+				if [ "$validarcfound" = 0 ]; then
+					echo "*** You have an old Xcode 8.3.3 archive with an expired signature"
+					echo "You should download the updated Xcode 8.3.3 archive. Login to:"
+				fi
+			fi
+			if [ "$noarcfound" = 1 ] || [ "$validarcfound" = 0 ]; then
+				echo " https://developer.apple.com/downloads/"
+				echo "then download from:"
+				echo " https://download.developer.apple.com/Developer_Tools/Xcode_8.3.3/Xcode_8.3.3.xip"
+				echo "and then run this script from within the same directory as the downloaded file"
+				missingdmg=1
+			fi
         fi
-        if [ "$xc9" = 1 ] && [ ! -f Xcode_9.4.1.xip ]; then
-            echo "*** You should download Xcode 9.4.1. Login to:"
-            echo " https://developer.apple.com/downloads/"
-            echo "then download from:"
-            echo " https://download.developer.apple.com/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip"
-            echo "and then run this script from within the same directory as the downloaded file"
-            missingdmg=1
+        if [ "$xc9" = 1 ]; then
+			validarcfound=0
+			noarcfound=0
+			if [ ! -f Xcode_9.4.1.xip ]; then
+				echo "*** You should download Xcode 9.4.1. Login to:"
+				noarcfound=1
+			else
+				pkgutil --check-signature Xcode_9.4.1.xip
+				if [ "$?" = 0 ]; then
+					validarcfound=1
+				else
+					echo "*** You have an old Xcode 9.4.1 archive with an expired signature"
+					echo "You should download the updated Xcode 9.4.1 archive. Login to:"
+				fi
+			fi
+			if [ "$noarcfound" = 1 ] || [ "$validarcfound" = 0 ]; then
+				echo " https://developer.apple.com/downloads/"
+				echo "then download from:"
+				echo " https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip"
+                echo "or"
+                echo " https://download.developer.apple.com/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip"
+				echo "and then run this script from within the same directory as the downloaded file"
+				missingdmg=1
+			fi
         fi
         if [ "$missingdmg" = 1 ]; then
             echo "*** at least one Xcode distribution is missing, cannot build packages - exiting now"
@@ -598,7 +642,7 @@ EOF
         if [ "$xc8" = 1 ]; then
             if [ "$osx1012" = 1 ]; then
                 echo "Extracting Mac OS X 10.12 SDK from Xcode 8.3.3. Be patient - this will take some time"
-                open Xcode8.3.3.xip
+                open "$xcode8archive"
                 while [ ! -d Xcode.app ]; do
                     sleep 5
                 done


### PR DESCRIPTION
Hello,

I'm submitting the following changes for your consideration.

On 24th October 2019 the certificate used to sign the Xcode 8.3.3 and Xcode 9.4.1 XIP archives had expired and when the script ran it hung when trying to unpack either of theses archives. The problem arose because Archive Utility checks the signature before unpacking and when the archive failed to verify it abandoned the unpack but as it had no way to return the failure to XcodeLegacy.sh the script hung waiting for 'Xcode.app' to appear.

The fixes to the script checks XIP archives for validity before attempting unpacking and prompts the user to re-download the archive (the currently available ones have been signed with a valid signature). It also copes with a change in name of the Xcode 8.3.3 archive and copes with the situation where a new archive has been downloaded and renamed to the old name.

I also fixed a few changed download links in the script and README, added missing documentation for the -path option and the version 2.3 changes.