### PR TITLE
Use `xip --expand` to open .xip archives

### DIFF
--- a/XcodeLegacy.sh
+++ b/XcodeLegacy.sh
@@ -676,11 +676,7 @@ EOF
         if [ "$xc8" = 1 ]; then
             if [ "$osx1012" = 1 ]; then
                 echo "Extracting Mac OS X 10.12 SDK from Xcode 8.3.3. Be patient - this will take some time"
-                open "$xcode8archive"
-                while [ ! -d Xcode.app ]; do
-                    sleep 5
-                done
-                sleep 5
+                xip --expand "$xcode8archive"
                 ( (cd "Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer" || exit; rm SDKs/MacOSX10.12.sdk; mv SDKs/MacOSX.sdk SDKs/MacOSX10.12.sdk; tar cf - SDKs/MacOSX10.12.sdk) | gzip -c > Xcode1012SDK.tar.gz) && echo "*** Created Xcode1012SDK.tar.gz in directory $(pwd)"
                 rm -rf Xcode.app
             fi
@@ -688,11 +684,7 @@ EOF
         if [ "$xc9" = 1 ]; then
             if [ "$osx1013" = 1 ]; then
                 echo "Extracting Mac OS X 10.13 SDK from Xcode 9.4.1. Be patient - this will take some time"
-                open Xcode_9.4.1.xip
-                while [ ! -d Xcode.app ]; do
-                    sleep 5
-                done
-                sleep 5
+                xip --expand Xcode_9.4.1.xip
                 ( (cd "Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer" || exit; rm SDKs/MacOSX10.13.sdk; mv SDKs/MacOSX.sdk SDKs/MacOSX10.13.sdk; tar cf - SDKs/MacOSX10.13.sdk) | gzip -c > Xcode1013SDK.tar.gz) && echo "*** Created Xcode1013SDK.tar.gz in directory $(pwd)"
                 rm -rf Xcode.app
             fi
@@ -700,11 +692,7 @@ EOF
 		if [ "$xc10" = 1 ]; then
             if [ "$osx1014" = 1 ]; then
                 echo "Extracting Mac OS X 10.14 SDK from Xcode 10.3. Be patient - this will take some time"
-                open Xcode_10.3.xip
-                while [ ! -d Xcode.app ]; do
-                    sleep 5
-                done
-                sleep 5
+                xip --expand Xcode_10.3.xip
                 ( (cd "Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer" || exit; rm SDKs/MacOSX10.14.sdk; mv SDKs/MacOSX.sdk SDKs/MacOSX10.14.sdk; tar cf - SDKs/MacOSX10.14.sdk) | gzip -c > Xcode1014SDK.tar.gz) && echo "*** Created Xcode1014SDK.tar.gz in directory $(pwd)"
                 rm -rf Xcode.app
             fi
@@ -712,11 +700,7 @@ EOF
 		if [ "$xc11" = 1 ]; then
             if [ "$osx1015" = 1 ]; then
                 echo "Extracting Mac OS X 10.15 SDK from Xcode 11.7. Be patient - this will take some time"
-                open Xcode_11.7.xip
-                while [ ! -d Xcode.app ]; do
-                    sleep 5
-                done
-                sleep 5
+                xip --expand Xcode_11.7.xip
                 ( (cd "Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer" || exit; rm SDKs/MacOSX10.15.sdk; mv SDKs/MacOSX.sdk SDKs/MacOSX10.15.sdk; tar cf - SDKs/MacOSX10.15.sdk) | gzip -c > Xcode1015SDK.tar.gz) && echo "*** Created Xcode1015SDK.tar.gz in directory $(pwd)"
                 rm -rf Xcode.app
             fi


### PR DESCRIPTION
Although the `xip` man page has only mentioned the `--expand` option since macOS 10.14 Mojave, it's actually been available for use ever since `xip` first appeared in OS X 10.7 Lion. Using `xip` instead of Archive Utility saves some time in my testing, most likely due to [less time spent on sandbox evaluation](https://threadreaderapp.com/thread/1481353292164698112).

Before: 5:35.59 total for Xcode_8.3.3.xip
```
eric@iMac27-en1 xcodelegacy % time ./XcodeLegacy.sh -osx1012 buildpackages
*** Info: found Xcode >= 4.3 in /Applications/Xcode.app
Package "Xcode_8.3.3.xip":
   Status: signed Apple Software
   Signed with a trusted timestamp on: 2019-10-05 01:05:05 +0000
   Certificate Chain:
      1. Software Update
       Expires: 2029-04-14 21:28:23 +0000
       SHA256 Fingerprint:
           E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66
           80 28 92 05 83 B1 E8 96 EB B4
       \------------------------------------------------------------------------
      2. Apple Software Update Certification Authority
       Expires: 2031-10-15 00:00:00 +0000
       SHA256 Fingerprint:
           12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D
           D1 85 0B 82 74 F3 5C 71 74 5C
       \------------------------------------------------------------------------
      3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24

Extracting Mac OS X 10.12 SDK from Xcode 8.3.3. Be patient - this will take some time
*** Created Xcode1012SDK.tar.gz in directory /Users/eric/Desktop/xcodelegacy
./XcodeLegacy.sh -osx1012 buildpackages  16.96s user 38.42s system 16% cpu 5:35.59 total
```
After: 5:26.57 total for Xcode_8.3.3.xip
```
eric@iMac27-en1 xcodelegacy % time ./XcodeLegacy.sh -osx1012 buildpackages
*** Info: found Xcode >= 4.3 in /Applications/Xcode.app
Package "Xcode_8.3.3.xip":
   Status: signed Apple Software
   Signed with a trusted timestamp on: 2019-10-05 01:05:05 +0000
   Certificate Chain:
      1. Software Update
       Expires: 2029-04-14 21:28:23 +0000
       SHA256 Fingerprint:
           E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66
           80 28 92 05 83 B1 E8 96 EB B4
       \------------------------------------------------------------------------
      2. Apple Software Update Certification Authority
       Expires: 2031-10-15 00:00:00 +0000
       SHA256 Fingerprint:
           12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D
           D1 85 0B 82 74 F3 5C 71 74 5C
       \------------------------------------------------------------------------
      3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24

Extracting Mac OS X 10.12 SDK from Xcode 8.3.3. Be patient - this will take some time
xip: signing certificate was "Software Update" (validation not attempted)
xip: expanded items from "/Users/eric/Desktop/xcodelegacy/Xcode_8.3.3.xip"
*** Created Xcode1012SDK.tar.gz in directory /Users/eric/Desktop/xcodelegacy
./XcodeLegacy.sh -osx1012 buildpackages  664.02s user 214.47s system 269% cpu 5:26.57 total
```

Before: 6:14.00 total for Xcode_9.4.1.xip
```
eric@iMac27-en1 xcodelegacy % time ./XcodeLegacy.sh -osx1013 buildpackages
*** Info: found Xcode >= 4.3 in /Applications/Xcode.app
Package "Xcode_9.4.1.xip":
   Status: signed Apple Software
   Signed with a trusted timestamp on: 2019-10-05 01:06:26 +0000
   Certificate Chain:
      1. Software Update
       Expires: 2029-04-14 21:28:23 +0000
       SHA256 Fingerprint:
           E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66
           80 28 92 05 83 B1 E8 96 EB B4
       \------------------------------------------------------------------------
      2. Apple Software Update Certification Authority
       Expires: 2031-10-15 00:00:00 +0000
       SHA256 Fingerprint:
           12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D
           D1 85 0B 82 74 F3 5C 71 74 5C
       \------------------------------------------------------------------------
      3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24

Extracting Mac OS X 10.13 SDK from Xcode 9.4.1. Be patient - this will take some time
*** Created Xcode1013SDK.tar.gz in directory /Users/eric/Desktop/xcodelegacy
./XcodeLegacy.sh -osx1013 buildpackages  16.94s user 50.63s system 18% cpu 6:14.00 total
```
After: 6:02.91 total for Xcode_9.4.1.xip
```
eric@iMac27-en1 xcodelegacy % time ./XcodeLegacy.sh -osx1013 buildpackages
*** Info: found Xcode >= 4.3 in /Applications/Xcode.app
Package "Xcode_9.4.1.xip":
   Status: signed Apple Software
   Signed with a trusted timestamp on: 2019-10-05 01:06:26 +0000
   Certificate Chain:
      1. Software Update
       Expires: 2029-04-14 21:28:23 +0000
       SHA256 Fingerprint:
           E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66
           80 28 92 05 83 B1 E8 96 EB B4
       \------------------------------------------------------------------------
      2. Apple Software Update Certification Authority
       Expires: 2031-10-15 00:00:00 +0000
       SHA256 Fingerprint:
           12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D
           D1 85 0B 82 74 F3 5C 71 74 5C
       \------------------------------------------------------------------------
      3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24

Extracting Mac OS X 10.13 SDK from Xcode 9.4.1. Be patient - this will take some time
xip: signing certificate was "Software Update" (validation not attempted)
xip: expanded items from "/Users/eric/Desktop/xcodelegacy/Xcode_9.4.1.xip"
*** Created Xcode1013SDK.tar.gz in directory /Users/eric/Desktop/xcodelegacy
./XcodeLegacy.sh -osx1013 buildpackages  700.24s user 247.13s system 261% cpu 6:02.91 total
```